### PR TITLE
Added better flags to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 #Release and debug
 ifeq ($(RELEASE), 1)
-	CXXFLAGS = -O3 -flto
+	CXXFLAGS = -O3 -flto -Wall -Wextra
 	LDFLAGS = -s
 	FILENAME_DEF = release
 else
-	CXXFLAGS = -O0 -ggdb3 -Wall -Wextra -pedantic -DDEBUG
+	CXXFLAGS = -Og -ggdb3 -Wall -Wextra -pedantic -DDEBUG
 	FILENAME_DEF = debug
 endif
 


### PR DESCRIPTION
Having warning in the release build shouldn't affect much ; It should even allow for more warnings since the warnings can go look across translation units during link time with flto.

Using Og instead of O0 makes it so that it's optimized for debugging instead of not being optimized at all (which disables some debugging stuff)