### PR TITLE
Made SDL2 the default backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ ifeq ($(WINDOWS), 1)
 	endif
 endif
 
+# If the user hasn't chosen a backend, just assume he wants SDL2
+BACKEND ?= SDL2
+
 #Backend flags and libraries
 ifeq ($(BACKEND), SDL2)
 	CXXFLAGS += `pkg-config --cflags sdl2` -DBACKEND_SDL2


### PR DESCRIPTION
If no backend is chosen, might as well make it so that one is chosen by default. As SDL2 is the only currently available backend, I've made it the default here.